### PR TITLE
Re-implement scbs matrix #7

### DIFF
--- a/scbs/cli.py
+++ b/scbs/cli.py
@@ -457,15 +457,20 @@ def diff_cli(**kwargs):
     for dimensionality reduction or clustering, analogous to a count matrix in
     scRNA-seq.
 
-    {style("REGIONS", fg="green")} is an alphabetically sorted (!) .bed file of regions
-    for which methylation will be quantified in every cell.
+    {style("REGIONS", fg="green")} is a .bed file of regions for which methylation
+    will be quantified in every cell.
 
     {style("DATA_DIR", fg="green")} is the directory containing the methylation
     matrices produced by running 'scbs prepare', as well as the smoothed methylation
     values produced by running 'scbs smooth'.
 
-    {style("OUTPUT", fg="green")} is the output directory where the count tables will
-    be written.
+    \b
+    {style("OUTPUT_DIR", fg="green")} is the output directory.
+    It will contain four cell × region matrices ("count tables"):
+    methylated_sites.csv.gz - the number of sites that were methylated
+    total_sites.csv.gz - the total number of observed sites (sites with read coverage)
+    methylation_fractions.csv.gz - the fraction of methylated sites (methylated / total)
+    mean_shrunken_residuals.csv.gz - the mean shrunken residuals, a measure of methylation
     """,
     short_help="Make a methylation matrix, similar to a count matrix in scRNA-seq",
     no_args_is_help=True,
@@ -475,7 +480,7 @@ def diff_cli(**kwargs):
     "data-dir",
     type=click.Path(exists=True, dir_okay=True, file_okay=False, readable=True),
 )
-@click.argument("output", type=click.Path(file_okay=False, writable=True))
+@click.argument("output_dir", type=click.Path(file_okay=False, writable=True))
 @click.option(
     "--threads",
     default=-1,

--- a/scbs/cli.py
+++ b/scbs/cli.py
@@ -469,8 +469,10 @@ def diff_cli(**kwargs):
     It will contain four cell × region matrices ("count tables"):
     methylated_sites.csv.gz - the number of sites that were methylated
     total_sites.csv.gz - the total number of observed sites (sites with read coverage)
-    methylation_fractions.csv.gz - the fraction of methylated sites (methylated / total)
-    mean_shrunken_residuals.csv.gz - the mean shrunken residuals, a measure of methylation
+    methylation_fractions.csv.gz - the average methylation, calculated as:
+        # of methylated sites / # of total observed sites
+    mean_shrunken_residuals.csv.gz - the mean shrunken residuals, a more accurate
+        measure of methylation in a genomic region.
     """,
     short_help="Make a methylation matrix, similar to a count matrix in scRNA-seq",
     no_args_is_help=True,

--- a/scbs/cli.py
+++ b/scbs/cli.py
@@ -464,9 +464,8 @@ def diff_cli(**kwargs):
     matrices produced by running 'scbs prepare', as well as the smoothed methylation
     values produced by running 'scbs smooth'.
 
-    {style("OUTPUT", fg="green")} is the file path where the count table will be
-    written. Should end with '.csv'. The table is in long format and missing values
-    are omitted.
+    {style("OUTPUT", fg="green")} is the output directory where the count tables will
+    be written.
     """,
     short_help="Make a methylation matrix, similar to a count matrix in scRNA-seq",
     no_args_is_help=True,
@@ -476,11 +475,12 @@ def diff_cli(**kwargs):
     "data-dir",
     type=click.Path(exists=True, dir_okay=True, file_okay=False, readable=True),
 )
-@click.argument("output", type=click.File("w"))
+@click.argument("output", type=click.Path(file_okay=False, writable=True))
 @click.option(
-    "--keep-other-columns",
-    is_flag=True,
-    help="Use this to keep any other columns that the input bed-file may contain.",
+    "--threads",
+    default=-1,
+    help="How many CPU threads to use in parallel.  [default: all available]",
+    callback=_set_n_threads,
 )
 def matrix_cli(**kwargs):
     from .matrix import matrix

--- a/scbs/matrix.py
+++ b/scbs/matrix.py
@@ -1,18 +1,12 @@
-import numba
 import os
+
+import numba
 import numpy as np
 import pandas as pd
-
 from numba import njit, prange
 
 from .smooth import _load_smoothed_chrom
-from .utils import (
-    _check_data_dir,
-    _iter_bed,
-    _load_chrom_mat,
-    _parse_cell_names,
-    echo,
-)
+from .utils import _check_data_dir, _iter_bed, _load_chrom_mat, _parse_cell_names, echo
 
 
 @njit(parallel=True)

--- a/scbs/utils.py
+++ b/scbs/utils.py
@@ -31,7 +31,7 @@ def _iter_bed(file_obj, strand_col_i=None, keep_cols=False):
     if strand_col_i is not None:
         strand_col_i -= 1  # CLI is 1-indexed
     for line in file_obj:
-        if line.startswith("#"):
+        if line.startswith("#") or not line.strip():
             continue  # skip comments
         values = line.strip().split("\t")
         if strand_col_i is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,10 +88,14 @@ def test_matrix_cli(tmp_path):
         ],
         input=bed,
     )
-    print(result.output)
     assert result.exit_code == 0, result.output
     mtx = read_csv(os.path.join(tmp_path, "mtx", "methylation_fractions.csv.gz"))
     assert mtx.values.tolist() == [["a", 0.5, 0.5], ["b", 0.0, 0.5]]
+    assert os.path.isfile(os.path.join(tmp_path, "mtx", "total_sites.csv.gz"))
+    assert os.path.isfile(os.path.join(tmp_path, "mtx", "methylated_sites.csv.gz"))
+    assert os.path.isfile(
+        os.path.join(tmp_path, "mtx", "mean_shrunken_residuals.csv.gz")
+    )
 
 
 def test_profile_cli():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,24 +76,22 @@ def test_scan_cli():
 
 
 def test_matrix_cli(tmp_path):
-    outfile = os.path.join(tmp_path, "mtx.csv")
     bed = "1\t50\t52\tx\n2\t1000\t1234\ty\n"
     runner = CliRunner()
     result = runner.invoke(
         cli,
         [
             "matrix",
-            "--keep-other-columns",
             "-",
             "tests/data/tiny/data_dir_smooth/",
-            outfile,
+            os.path.join(tmp_path, "mtx"),
         ],
         input=bed,
     )
-    mtx = read_csv(outfile)
+    print(result.output)
     assert result.exit_code == 0, result.output
-    assert mtx["meth_frac"].values.tolist() == [0.5, 0.0, 0.5, 0.5]
-    assert mtx["bed_col4"].values.tolist() == ["x", "x", "y", "y"]
+    mtx = read_csv(os.path.join(tmp_path, "mtx", "methylation_fractions.csv.gz"))
+    assert mtx.values.tolist() == [["a", 0.5, 0.5], ["b", 0.0, 0.5]]
 
 
 def test_profile_cli():


### PR DESCRIPTION
Previously, scbs matrix produced a big table in "long" format. When you have many cells or genomic regions, this file got very huge and unwieldy.
Now, scbs matrix produces a directory with four regular "wide" matrices (i.e., cell x region matrices): A matrix containing the methylation fractions, a matrix containing the mean shrunken residuals, a matrix containing the number of methylated sites, and a matrix containing the number of total observed cites.